### PR TITLE
Added Jetson Nano repository

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -9,6 +9,8 @@
 echo "deb https://seeed-studio.github.io/pi_repo/ stretch main" | sudo tee /etc/apt/sources.list.d/seeed.list
 # Coral Dev Board
 echo "deb https://seeed-studio.github.io/pi_repo/ mendel-beaker main" | sudo tee /etc/apt/sources.list.d/seeed.list
+#For Nvidia Jetson nano
+echo "deb https://seeed-studio.github.io/pi_repo/ bionic main" | sudo tee /etc/apt/sources.list.d/seeed.list
 ```
 
 - Add public GPG key


### PR DESCRIPTION
The INSTALL.md file did not contail a repository for the Jetson Nano. In 
https://github.com/Seeed-Studio/grove.py/blob/master/doc/INSTALL.md#install-dependencies I found the info to add this repository to the INSTALL.md file