### PR TITLE
grove_imu_9dof_icm20600_ak09918.py - incosistent use of tabs and spaces

### DIFF
--- a/grove/grove_imu_9dof_icm20600_ak09918.py
+++ b/grove/grove_imu_9dof_icm20600_ak09918.py
@@ -202,8 +202,8 @@ class GroveIMU9DOFAK09918(object):
 
     def is_ready(self):
         if _akicm.rpi_ak09918_is_ready(self._dev) == AK09918_ERR_OK:
-	    return True
-	return False
+            return True
+        return False
 
     def is_skip(self):
         r = _akicm.rpi_ak09918_is_skip(self._dev)


### PR DESCRIPTION
Replaced tabs with spaces to avoid "inconsistent use" error.