### PR TITLE
Adding install of pip for RPi

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -215,6 +215,9 @@ jetson_nano)
 	popd	
 	;;
 rpi)
+	apt_install python-pip	
+	apt_install python3-pip
+	
 	### install I2C ###
 	if [ $(get_i2c) -ne 0 ]; then
 		# enable i2c interface


### PR DESCRIPTION
On a clean Raspberry Pi, this installer fails as it depends on Pip, which is not installed by default on Raspberry Pi OS Lite.

This change installs pip for Python 2 and Python 3.

This should fix #28