### PR TITLE
temperature MCP9808: add I2C address of device

### DIFF
--- a/grove/factory/factory.py
+++ b/grove/factory/factory.py
@@ -143,11 +143,11 @@ class __factory(object):
             self.__avail_list(typ, self.OneLedEnum)
             sys.exit(1)
 
-    def getTemper(self, typ, channel = None):
+    def getTemper(self, typ, channel = None, address=0x18):
         if typ == "NTC-ADC":
             return TemperTypedNTC(channel)
         elif typ == "MCP9808-I2C":
-            return TemperMCP9808()
+            return TemperMCP9808(address=address)
         else:
             self.__avail_list(typ, self.TemperEnum)
             sys.exit(1)

--- a/grove/grove_high_accuracy_temperature.py
+++ b/grove/grove_high_accuracy_temperature.py
@@ -39,7 +39,10 @@ def main():
     print("Insert Grove - I2C-High-Accuracy-Temperature")
     print("  to Grove-Base-Hat any I2C slot")
 
-    sensor = Factory.getTemper("MCP9808-I2C")
+    #I2C address of temperature device: 0x18 (default) to 0x1F
+    i2c_id=0x18
+
+    sensor = Factory.getTemper("MCP9808-I2C", address=i2c_id)
     sensor.resolution(Temper.RES_1_16_CELSIUS)
 
     print('Detecting temperature...')

--- a/grove/temperature/mcp9808.py
+++ b/grove/temperature/mcp9808.py
@@ -38,8 +38,8 @@ from grove.temperature import Temper
 from upm.pyupm_mcp9808 import MCP9808
 
 class TemperMCP9808(Temper):
-    def __init__(self):
-        self.mcp = MCP9808(I2C.MRAA_I2C)
+    def __init__(self, address=0x18):
+        self.mcp = MCP9808(I2C.MRAA_I2C,address=address)
         self.mcp.setMode(True)  # Celsius
         self._resolution = Temper.RES_1_2_CELSIUS
 


### PR DESCRIPTION
add I2C address of device in code as parameter, so any device can be chosen from 0x18 to 0x1F, default is 0x18 in all class.