### PR TITLE
Create multiple i2c buses

### DIFF
--- a/grove/i2c.py
+++ b/grove/i2c.py
@@ -47,8 +47,8 @@ class Bus:
                 bus = 1  # for Pi 2+
             else:
                 bus = 0
-        if not Bus.instance:
-            Bus.instance = smbus.SMBus(bus)
+        if not self.instance:
+            self.instance = smbus.SMBus(bus)
         self.bus = bus
         self.msg = i2c_msg
     def __getattr__(self, name):


### PR DESCRIPTION
Add ability to create multiple i2c buses. `i2c.Bus` class is no longer a singleton.

Follow up on issue #56 using code change from @nikolozka.